### PR TITLE
Use more flexible requests library

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,16 @@ Installation
 
 The library is compatible with Python 2 and Python 3.
 
+Prerequisites
+=============
+
+The library needs the requests library
+
+.. code-block:: bash
+
+    pip install requests
+
+
 Examples
 ========
 

--- a/requests.txt
+++ b/requests.txt
@@ -1,0 +1,1 @@
+requests>1.0


### PR DESCRIPTION
Add support for additional HTTP Basic authorization.
Add support for proxies.
Add support for (disabling) SSL verification.

The reason behind using requests is that it's much easier to add support for proxies, disabling SSL verification, and *additional* authorization. If kanboard is behind HTTP Basic Auth, this enables you to use both authorizations at the same time.