### PR TITLE
Fix custom auth headers

### DIFF
--- a/kanboard/client.py
+++ b/kanboard/client.py
@@ -31,6 +31,9 @@ except ImportError:
     import urllib2 as http
 
 
+DEFAULT_AUTH_HEADER = 'Authorization'
+
+
 class Kanboard(object):
     """
     Kanboard API client
@@ -47,7 +50,7 @@ class Kanboard(object):
 
     """
 
-    def __init__(self, url, username, password, auth_header='Authorization'):
+    def __init__(self, url, username, password, auth_header=DEFAULT_AUTH_HEADER):
         """
         Constructor
 
@@ -120,8 +123,9 @@ class Kanboard(object):
         }
 
         credentials = base64.b64encode('{}:{}'.format(self._username, self._password).encode())
+        auth_header_prefix = 'Basic ' if self._auth_header == DEFAULT_AUTH_HEADER else ''
         headers = {
-            self._auth_header: 'Basic {}'.format(credentials.decode()),
+            self._auth_header: auth_header_prefix + credentials.decode(),
             'Content-Type': 'application/json',
         }
 

--- a/kanboard/tests/test_kanboard.py
+++ b/kanboard/tests/test_kanboard.py
@@ -43,6 +43,15 @@ class TestKanboard(unittest.TestCase):
                                              data=mock.ANY,
                                              headers=mock.ANY)
 
+    def test_custom_auth_header(self):
+        self.client._auth_header = 'X-Auth-Header'
+        body = b'{"jsonrpc": "2.0", "result": true, "id": 123}'
+        self.urlopen.return_value.read.return_value = body
+        self.assertEquals(True, self.client.remote_procedure())
+        self.request.assert_called_once()
+        _, kwargs = self.request.call_args
+        assert kwargs['headers']['X-Auth-Header'] == 'dXNlcm5hbWU6cGFzc3dvcmQ='
+
     def test_http_error(self):
         self.urlopen.side_effect = Exception()
         with self.assertRaises(exceptions.KanboardClientException):


### PR DESCRIPTION
I was trying to work around https://github.com/kanboard/kanboard/issues/1953 when I eventually found out that authentication worked via `curl` but failed via the API. Fortunately it was pretty obvious to find the issue in the code: the authentication method identifier `Basic` shouldn't appear in the header value except when using the standard HTTP `Authentication` header.