### PR TITLE
Adds support for async/await API calls (no deps)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 dist
 build
 MANIFEST
+__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ notifications:
 language: python
 
 python:
-  - '2.7'
-  - '3.4'
   - '3.5'
   - '3.6'
 

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Installation
     pip install kanboard
 
 
-This library is compatible with Python 2.7, 3.4, 3.5, 3.6, and 3.7.
+This library is compatible with Python 3.5, 3.6, and 3.7.
 
 Examples
 ========
@@ -26,6 +26,8 @@ Examples
 Methods and arguments are the same as the JSON-RPC procedures described in the `official documentation <https://docs.kanboard.org/en/latest/api/index.html>`_.
 
 Python methods are dynamically mapped to the API procedures. You must use named arguments.
+
+By default, the calls are made synchronously, meaning that they will block the program until completed.
 
 Create a new team project
 -------------------------
@@ -58,5 +60,34 @@ Create a new task
     kb = Kanboard('http://localhost/jsonrpc.php', 'jsonrpc', 'your_api_token')
     project_id = kb.create_project(name='My project')
     task_id = kb.create_task(project_id=project_id, title='My task title')
+
+Asynchronous I/O
+================
+
+The client also exposes async/await style method calls. Similarly to the synchronous calls (see above), the method names are mapped to the API methods.
+To invoke an asynchronous call, the method name must be appended with `_async`: for example, a synchronous call to `create_project` can be made asynchronous by calling `create_project_async` instead.
+
+.. code-block:: python
+
+    import asyncio
+    from kanboard import Kanboard
+
+    kb = Kanboard('http://localhost/jsonrpc.php', 'jsonrpc', 'your_api_token')
+
+    loop = asyncio.get_event_loop()
+    project_id = loop.run_until_complete(kb.create_project_async(name='My project'))
+
+
+.. code-block:: python
+
+    import asyncio
+    from kanboard import Kanboard
+
+    async def call_within_function()
+      kb = Kanboard('http://localhost/jsonrpc.php', 'jsonrpc', 'your_api_token')
+      return await kb.create_project_async(name='My project')
+
+    loop = asyncio.get_event_loop()
+    project_id = loop.run_until_complete(call_within_function())
 
 See the `official API documentation <https://docs.kanboard.org/en/latest/api/index.html>`_ for the complete list of methods and arguments.

--- a/kanboard/client.py
+++ b/kanboard/client.py
@@ -79,7 +79,9 @@ class Kanboard(object):
             async def function(*args, **kwargs):
                 return await self._event_loop.run_in_executor(
                     None,
-                    functools.partial(self.execute, method=self._to_camel_case(self.get_funcname_from_async_name(name)), **kwargs))
+                    functools.partial(
+                        self.execute,
+                        method=self._to_camel_case(self.get_funcname_from_async_name(name)), **kwargs))
             return function
         else:
             def function(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def readme():
 
 setup(
     name='kanboard',
-    version='1.0.7',
+    version='1.1.0',
     description='Client library for Kanboard API',
     long_description=readme(),
     keywords='kanboard api client',
@@ -47,8 +47,6 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,1 @@
 flake8
-mock


### PR DESCRIPTION
**BREAKING**:
Drops support for python 2.7 and < 3.5 (it relies on asyncio (so 2.7 is out), and python versions below 3.5 have different behaviours regarding the thread pool, see: https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_in_executor).

I am suggesting this change for your consideration.
Backwards compatibility has been preserved by running the synchronous `kanboard.client.Kanboard.execute` method into an asyncio executor (for now, only the default executor can be used, but the event loop can be customised via Kanboard() ctor)

Basic usage is to use the coroutines mapped by method calls with the _async suffix.
Example: for a given `kb` object (of type Kanboard)
Synchronous: `kb.create_project(name="My project")`
Asynchronous: `kb.create_project_async(name="My project")`

Fixes #14 (replaces PR #15)