### PR TITLE
Fix async get_event_loop call when not in main thread

### DIFF
--- a/kanboard.py
+++ b/kanboard.py
@@ -57,7 +57,7 @@ class Client:
                  password,
                  auth_header=DEFAULT_AUTH_HEADER,
                  cafile=None,
-                 loop=asyncio.get_event_loop()):
+                 loop=None):
         """
         Constructor
 
@@ -74,7 +74,12 @@ class Client:
         self._password = password
         self._auth_header = auth_header
         self._cafile = cafile
-        self._event_loop = loop
+
+        if not loop:
+            try:
+                self._event_loop = asyncio.get_event_loop()
+            except RuntimeError:
+                self._event_loop = asyncio.new_event_loop()
 
     def __getattr__(self, name):
         if self.is_async_method_name(name):

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='kanboard',
-    version='1.1.1',
+    version='1.1.2',
     description='Client library for Kanboard API',
     long_description=readme(),
     keywords='kanboard api client',


### PR DESCRIPTION
resolves #19 

Hopefully this will resolve the issue by deferring the get_event_loop to object instantiation, as opposed to with module import, and handle the lack of presence of an event loop with the calling thread. 

