### PR TITLE
Add note about Fedora package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,13 @@ This library is compatible with Python >= 3.5.
 
 Note: **Support for Python 2.7 has been dropped since version 1.1.0.**
 
+On Fedora (36 and later), you can install the package using DNF:
+
+.. code-block:: bash
+
+    dnf install python3-kanboard
+
+
 Examples
 ========
 


### PR DESCRIPTION
**Note about this PR:**

Feel free to drop this if you intentionally don't advertise distro packages in the README.rst.

**Original commit message:**

> Package python3-kanboard [has been added][1] to Fedora 36 (as of now, this is
> pre-relase Rawhide version called "rawhide" and [scheduled for release][2] in
> few months).
>
>   [1]: https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=2009450
>   [2]: https://fedorapeople.org/groups/schedule/f-36/f-36-key-tasks.html
